### PR TITLE
RouteInformation.unmarshal: Comply with RFC4191 2.3

### DIFF
--- a/option.go
+++ b/option.go
@@ -338,7 +338,7 @@ func (ri *RouteInformation) unmarshal(b []byte) error {
 			return err
 		}
 	case l > 0 && l < 65:
-		if raw.Length != 2 {
+		if raw.Length < 2 || raw.Length > 3 {
 			return err
 		}
 	case l > 64 && l < 129:


### PR DESCRIPTION
Per the RFC: "If Prefix Length is greater than 0, then Length must be
2 or 3."  This change updates RouteInformation.unmarshal to permit
Length to be 3 for prefixes of length [1, 64].